### PR TITLE
simple one-liner to enable dark mode

### DIFF
--- a/grbl-gui.py
+++ b/grbl-gui.py
@@ -246,6 +246,7 @@ def main():
 
     elif subcmd == "gui":
         app = QApplication(sys.argv)
+        app.setStyle('Fusion')
         window = MainWindow(args.path, int(args.baud))
         window.show()
         sys.exit(app.exec())


### PR DESCRIPTION
This one line enables QT to go into dark mode, which looks pretty good I must say with no other changes.

![image](https://github.com/michaelfranzl/grbl-gui/assets/934651/92c1215e-04f3-4fd3-b8ff-0fb188f73bfc)
